### PR TITLE
Add note about client type

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With this package, you can set up your Chrome extension to use Auth0's hosted [L
 
 ### Getting Started
 
-If you haven't already done so, [sign up](https://auth0.com/signup) for your free Auth0 account and create an application in the dashboard. Find the **domain** and **client ID** from your app settings, as these will be required to integrate Auth0 in your Chrome extension.
+If you haven't already done so, [sign up](https://auth0.com/signup) for your free Auth0 account and create an application in the dashboard. Find the **domain** and **client ID** from your app settings, as these will be required to integrate Auth0 in your Chrome extension. Note that the client type that you use has to be `Native`, or you will get unauthorized errors.
 
 Chrome extensions are packaged as `.crx` files for distribution but may be loaded "unpacked" for development. For more information on how to load an unpacked extension, see the [Chrome extension docs](https://developer.chrome.com/extensions/getstarted#unpacked).
 


### PR DESCRIPTION
We ran into an issue when using this project to perform auth for our chrome extension where we were getting 401 Unauthorized errors and couldn't figure out why. Turns out we'd incorrectly configured our client type. Wanted to put in a note so that others can avoid our silly rabbit hole in the future =).