### PR TITLE
Update client reference in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ To read more on this go to [Customize Your Hosted Page](https://auth0.com/docs/h
 
 ### Using the Library
 
-* Auth0CLient(domain, clientId)
+* Auth0Chrome(domain, clientId)
 
-    The library exposes `Auth0Client` which extends a generic `PKCEClient`.
+    The library exposes `Auth0Chrome` which extends a generic `PKCEClient`.
 
     - `domain` : Your Auth0 Domain, to create one please visit https://auth0.com/
     - `clientId`: The clientId for the chrome client, to create one
-    - Visit https://manage.auth0.com/#/clients and click on  `+ Create Client`
+    - Visit https://manage.auth0.com/#/clients and click on  `+ Create Application`
     - Select "Native" as the client type
     - In the **Allowed Callback URLs** section, add `https://<yourchromeappid>.chromiumapps.org/auth0` as an allowed callback url
     - In the **Allowed Origins** section, add `chrome-extension://<yourchromeappid>`


### PR DESCRIPTION
### Description

This small PR updates the readme to reference the exposed client correctly (`Auth0Chrome`) and to mention `Applications` instead of `Clients` in auth0.

A similar update should be made to the text and screenshots in [this tutorial](https://auth0.com/docs/quickstart/native/chrome/01-login).